### PR TITLE
Fix - #2264 - Refactor verbiage in tW tool description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Status](https://travis-ci.org/translationCoreApps/translationWords_Check_plugin.
 
 # translationWords
 
-A tool to comprehensively check the meaning of all key terms in the Bible using a set of clear, concise definitions and including suggestions for translation.
+A tool to comprehensively check the meaning of key terms in the Bible using a set of clear, concise definitions and including suggestions for translation.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "translationWords",
   "version": "1.0.3",
-  "description": "A tool to comprehensively check the meaning of all key terms in the Bible using a set of clear, concise definitions and including suggestions for translation.",
+  "description": "A tool to comprehensively check the meaning of key terms in the Bible using a set of clear, concise definitions and including suggestions for translation.",
   "title": "translationWords (Part 1)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### This pull request addresses:

Removes "all" from tW Tool description


#### How to test this pull request:

See the description of the tW Tool to make sure it says "check the meaning of key terms" rather than "check the meaning of *all* key terms"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords/105)
<!-- Reviewable:end -->
