### PR TITLE
Enhancement - #3305 - CheckCard uses Gateway Language resources index.json

### DIFF
--- a/__tests__/Container.test.js
+++ b/__tests__/Container.test.js
@@ -20,6 +20,9 @@ const props = {
       groupId: 'groupId1'
     }
   },
+  groupsIndexReducer: {
+    groupsIndex: [{'id': 'groupId1', 'name': 'group title'}, {'id': 'groupId2', 'name': 'group title2'}]
+  },
   actions: {
     setToolSettings: jest.fn(),
     loadResourceArticle: jest.fn()

--- a/__tests__/View.test.js
+++ b/__tests__/View.test.js
@@ -31,6 +31,7 @@ describe('View component Tests', () => {
           quote: 'title'
         }
       },
+      title: 'title',
       toggleHelps: jest.fn(),
       showHelps: jest.fn()
     };

--- a/__tests__/__snapshots__/Container.test.js.snap
+++ b/__tests__/__snapshots__/Container.test.js.snap
@@ -15,6 +15,20 @@ exports[`Container Tests Test Container 1`] = `
       },
     }
   }
+  groupsIndexReducer={
+    Object {
+      "groupsIndex": Array [
+        Object {
+          "id": "groupId1",
+          "name": "group title",
+        },
+        Object {
+          "id": "groupId2",
+          "name": "group title2",
+        },
+      ],
+    }
+  }
   settingsReducer={
     Object {
       "toolsSettings": Object {
@@ -27,6 +41,7 @@ exports[`Container Tests Test Container 1`] = `
     }
   }
   showHelps={true}
+  title="group title"
   toggleHelps={[Function]}
 />
 `;

--- a/src/Container.js
+++ b/src/Container.js
@@ -66,6 +66,9 @@ Container.propTypes = {
       groupId: PropTypes.any
     })
   }),
+  groupsIndexReducer: PropTypes.shape({
+    groupsIndex: PropTypes.array
+  }),
   actions: PropTypes.shape({
     setToolSettings: PropTypes.func.isRequired,
     loadResourceArticle: PropTypes.func.isRequired

--- a/src/Container.js
+++ b/src/Container.js
@@ -42,8 +42,11 @@ class Container extends React.Component {
     let view = <div />;
     let { contextId } = this.props.contextIdReducer;
     if (contextId !== null) {
+      const { groupId } = this.props.contextIdReducer.contextId;
+      const title = this.props.groupsIndexReducer.groupsIndex.filter(item=>item.id===groupId)[0].name;
       view = <View
         {...this.props}
+        title={title}
         showHelps={this.state.showHelps}
         toggleHelps={this.toggleHelps.bind(this)}
       />;
@@ -62,6 +65,9 @@ Container.propTypes = {
     contextId: PropTypes.shape({
       groupId: PropTypes.any
     })
+  }),
+  groupsIndexReducer: PropTypes.shape({
+    groupsIndex: PropTypes.array.required
   }),
   actions: PropTypes.shape({
     setToolSettings: PropTypes.func.isRequired,

--- a/src/Container.js
+++ b/src/Container.js
@@ -66,9 +66,6 @@ Container.propTypes = {
       groupId: PropTypes.any
     })
   }),
-  groupsIndexReducer: PropTypes.shape({
-    groupsIndex: PropTypes.array.required
-  }),
   actions: PropTypes.shape({
     setToolSettings: PropTypes.func.isRequired,
     loadResourceArticle: PropTypes.func.isRequired

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -31,12 +31,16 @@ class View extends React.Component {
     if (translationWords && translationWords[articleId]) {
       currentFile = this.props.resourcesReducer.translationHelps.translationWords[articleId];
     }
+    let title;
+    if (this.props.groupsIndexReducer.groupsIndex) {
+      title = this.props.groupsIndexReducer.groupsIndex.filter(item=>item.id===articleId)[0].name;
+    }
 
     return (
       <div style={{display: 'flex', flex: 'auto'}}>
         <div style={{flex: '2 1 900px', display: "flex", flexDirection: "column"}}>
           {scripturePane}
-          <CheckInfoCard openHelps={this.props.toggleHelps} showHelps={this.props.showHelps} title={this.props.contextIdReducer.contextId.quote} file={currentFile}/>
+          <CheckInfoCard openHelps={this.props.toggleHelps} showHelps={this.props.showHelps} title={title} file={currentFile}/>
           <VerseCheck {...this.props} />
         </div>
         <div style={{flex: this.props.showHelps ? '1 1 375px' : '0 0 30px', display: 'flex', justifyContent: 'flex-end', marginLeft: '-15px'}}>

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -16,6 +16,7 @@ class View extends React.Component {
   render() {
     // Modules not defined within translationWords
     const { ScripturePane, VerseCheck, TranslationHelps } = this.props.currentToolViews;
+    const { title } = this.props;
 
     // set the scripturePane to empty to handle react/redux when it first renders without required data
     let scripturePane = <div></div>;
@@ -30,10 +31,6 @@ class View extends React.Component {
     let currentFile;
     if (translationWords && translationWords[articleId]) {
       currentFile = this.props.resourcesReducer.translationHelps.translationWords[articleId];
-    }
-    let title;
-    if (this.props.groupsIndexReducer.groupsIndex) {
-      title = this.props.groupsIndexReducer.groupsIndex.filter(item=>item.id===articleId)[0].name;
     }
 
     return (
@@ -83,6 +80,7 @@ View.propTypes = {
       quote: PropTypes.string.isRequired
     })
   }),
+  title: PropTypes.string.isRequired,
   toggleHelps: PropTypes.any.isRequired,
   showHelps: PropTypes.any.isRequired
 };


### PR DESCRIPTION
NOTE: Dependent on https://github.com/unfoldingWord-dev/translationCore/pull/3859 also being merged.

#### Describe what your pull request addresses (Please include relevant issue numbers):
- Gets the Group Index from the resources directory based on the Gateway language (currently hard coded as 'en' due to there not being a Gateway Language reducer, to be fixed in #3858) rather than from the project directory, thus no longer copies in the group index.json file. This causes the Check Info card to properly show the title of the selected tW word.

#### Please include detailed Test instructions for your pull request:
- Checkout enhancement-3305-tw-check-info in the main tC repo (https://github.com/unfoldingWord-dev/translationCore/pull/3859) AND in the tC_apps/translationWords repo, load a new project, go into tW. Words should be properly show up as English on the left menu and in the Check Info card. In the `<user>/translationCore/projects/<project>/.apps/translationCore/index/translationWords` directory there should NO LONGER be a index.json file, as we now read it from `<user>/translationCore/resources/en/translationHelps/translationWords/v6/kt`

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords/110)
<!-- Reviewable:end -->
