### PR TITLE
added compatibility for future scripture pane updates

### DIFF
--- a/src/components/View.js
+++ b/src/components/View.js
@@ -14,16 +14,33 @@ import PropTypes from 'prop-types';
 class View extends React.Component {
 
   render() {
-    const {translate} = this.props;
+    const {
+      title,
+      translate,
+      projectDetailsReducer,
+      appLanguage,
+      selectionsReducer,
+      currentToolViews,
+      resourcesReducer,
+      contextIdReducer,
+      settingsReducer,
+      actions
+    } = this.props;
     // Modules not defined within translationWords
-    const { ScripturePane, VerseCheck, TranslationHelps } = this.props.currentToolViews;
-    const { title } = this.props;
+    const { ScripturePane, VerseCheck, TranslationHelps } = currentToolViews;
 
     // set the scripturePane to empty to handle react/redux when it first renders without required data
     let scripturePane = <div/>;
     // populate scripturePane so that when required data is preset that it renders as intended.
     if (this.props.settingsReducer.toolsSettings.ScripturePane !== undefined) {
-      scripturePane = <ScripturePane {...this.props} />;
+      scripturePane = <ScripturePane projectDetailsReducer={projectDetailsReducer}
+                                     appLanguage={appLanguage}
+                                     selectionsReducer={selectionsReducer}
+                                     currentToolViews={currentToolViews}
+                                     resourcesReducer={resourcesReducer}
+                                     contextIdReducer={contextIdReducer}
+                                     settingsReducer={settingsReducer}
+                                     actions={actions} />;
     }
 
     let { translationWords } = this.props.resourcesReducer.translationHelps;
@@ -60,6 +77,10 @@ class View extends React.Component {
 }
 
 View.propTypes = {
+  actions: PropTypes.object.isRequired,
+  projectDetailsReducer: PropTypes.object.isRequired,
+  appLanguage: PropTypes.string.isRequired,
+  selectionsReducer: PropTypes.object.isRequired,
   translate: PropTypes.func.isRequired,
   currentToolViews: PropTypes.shape({
     ScripturePane: PropTypes.any,


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This contains some minor improvements to parameter passing to support future changes to the ScripturePane. This is required for https://github.com/unfoldingWord-dev/translationCore/issues/2004

#### Please include detailed Test instructions for your pull request:
- make sure the scripture pane still opens.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords/117)
<!-- Reviewable:end -->
