### PR TITLE
corrects the display of the check completion icon

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -116,7 +116,6 @@ const mapStateToProps = (state, ownProps) => {
       groupMenuReducer: ownProps.tc.groupMenuReducer,
       translate: ownProps.translate,
       actions: ownProps.tc.actions,
-      isVerseFinished: (chapter, verse) => getIsVerseFinished('wordAlignment', ownProps, chapter, verse),
       contextId: getContextId(ownProps),
       manifest: getManifest(ownProps),
       projectSaveLocation: getProjectSaveLocation(ownProps)


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Related to https://github.com/unfoldingWord-dev/translationCore/issues/4774
- Previously tW was using the completion state from wA when rendering the menu. This fixes the display of the check mark icon to use state from tW.


#### Please include detailed Test instructions for your pull request:
- Find a verse in tW that has **not** been marked as complete (no green check mark)
- Mark that verse as complete in wA.
- Ensure the verse in tW has not been marked as complete.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords/148)
<!-- Reviewable:end -->
