### PR TITLE
fixes checkmark displaying with the invalid icon

### DIFF
--- a/src/containers/GroupMenuContainer.js
+++ b/src/containers/GroupMenuContainer.js
@@ -50,7 +50,8 @@ class GroupMenuContainer extends React.Component {
     return {
       ...item,
       title: `${passageText} ${selectionText}`,
-      itemId: `${occurrence}:${bookId}:${chapter}:${verse}:${quote}`
+      itemId: `${occurrence}:${bookId}:${chapter}:${verse}:${quote}`,
+      finished: !!item.selections && !item.invalidated
     };
   };
 
@@ -77,16 +78,16 @@ class GroupMenuContainer extends React.Component {
       },
       {
         label: translate('menu.selected'),
-        key: 'selections',
-        disables: ['no-selections'],
+        key: 'finished',
+        disables: ['not-finished'],
         icon: <CheckIcon/>
       },
       {
         label: translate('menu.no_selection'),
-        id: 'no-selections',
-        key: 'selections',
+        id: 'not-finished',
+        key: 'finished',
         value: false,
-        disables: ['selections'],
+        disables: ['finished'],
         icon: <BlockIcon/>
       },
       {
@@ -103,7 +104,7 @@ class GroupMenuContainer extends React.Component {
 
     const statusIcons = [
       {
-        key: 'selections',
+        key: 'finished',
         icon: <CheckIcon style={{color: "#58c17a"}}/>
       },
       {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Related to https://github.com/unfoldingWord-dev/translationCore/issues/5599
- Fixes the checkmark being displayed when the check item is invalid.

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords/243)
<!-- Reviewable:end -->
