### PR TITLE
Fix For Clearing Invalidated Selections

### DIFF
--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -25,9 +25,6 @@ describe('api.validateBook', () => {
         },
         contextId: {reference: {bookId: 'tit'}},
         username: 'royalsix',
-        actions: {
-          changeSelections: jest.fn(() => {})
-        },
         project: {
           _projectPath: projectPath,
           getGroupData: jest.fn(() => {}),
@@ -37,14 +34,14 @@ describe('api.validateBook', () => {
               [{"priority": 1, "comments": false, "reminders": false, "selections": [{"text": "godlessness ", "occurrence": 1, "occurrences": 1}], "verseEdits": false, "contextId": {"reference": {"bookId": "tit", "chapter": 2, "verse": 12}, "tool": "translationWords", "groupId": "age", "quote": "αἰῶνι", "strong": ["G01650"], "occurrence": 1}, "invalidated": false}]
           })),
         },
-        showIgnorableAlert: jest.fn(() => {})
+        showIgnorableDialog: jest.fn(() => {})
       }
     };
     const api = new Api();
     const writeCheckDataSpy = jest.spyOn(api, 'writeCheckData');
     api.props = props;
     api.validateBook();
-    expect(props.tc.showIgnorableAlert).toHaveBeenCalled();
+    expect(props.tc.showIgnorableDialog).toHaveBeenCalled();
     expect(writeCheckDataSpy).toHaveBeenCalled();
     expect(fs.outputJSONSync).toHaveBeenCalledWith(
       expect.stringContaining(path.join(projectPath, '.apps/translationCore/checkData/selections/tit/2/12/')),

--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -41,27 +41,31 @@ describe('api.validateBook', () => {
       }
     };
     const api = new Api();
+    const writeCheckDataSpy = jest.spyOn(api, 'writeCheckData');
     api.props = props;
     api.validateBook();
     expect(props.tc.showIgnorableAlert).toHaveBeenCalled();
-    expect(props.tc.actions.changeSelections).toHaveBeenCalled();
+    expect(writeCheckDataSpy).toHaveBeenCalled();
     expect(fs.outputJSONSync).toHaveBeenCalledWith(
-      expect.stringContaining(path.join(projectPath, '.apps/translationCore/checkData/invalidated/tit/2/12/')),
+      expect.stringContaining(path.join(projectPath, '.apps/translationCore/checkData/selections/tit/2/12/')),
       {
-        contextId:
-        {
-          reference: {bookId: 'tit', chapter: 1, verse: 6},
-          tool: 'translationWords',
-          groupId: 'accuse',
-          quote: 'κατηγορίᾳ',
-          strong: ['G27240'],
-          occurrence: 1
+        contextId: {
+          groupId: "accuse",
+          occurrence: 1,
+          quote: "κατηγορίᾳ",
+          reference: {
+            bookId: "tit",
+            chapter: 1,
+            verse: 6
+          },
+          strong: ["G27240"],
+          tool: "translationWords"
         },
-        invalidated: true,
-        userName: 'royalsix',
+        gatewayLanguageCode: "en",
+        gatewayLanguageQuote: "accused",
         modifiedTimestamp: expect.any(String),
-        gatewayLanguageCode: 'en',
-        gatewayLanguageQuote: 'accused'
+        selections: [],
+        userName: "royalsix"
       }
     );
   });

--- a/src/Api.js
+++ b/src/Api.js
@@ -120,17 +120,17 @@ export default class Api extends ToolApi {
               selectionsChanged = true;
               const invalidatedCheckPath = path.join(projectSaveLocation, '.apps', 'translationCore', 'checkData', 'invalidated', bookId, chapter.toString(), verse.toString());
               const invalidatedPayload = {
+                ...selectionsObject,
                 invalidated: true,
-                userName,
-                ...selectionsObject
+                userName
               };
               this.writeCheckData(invalidatedPayload, invalidatedCheckPath);
 
               const selectionsCheckPath = path.join(projectSaveLocation, '.apps', 'translationCore', 'checkData', 'selections', bookId, chapter.toString(), verse.toString());
               const selectionsPayload = {
+                ...selectionsObject,
                 selections: [],
-                userName,
-                ...selectionsObject
+                userName
               };
               this.writeCheckData(selectionsPayload, selectionsCheckPath);
             }
@@ -146,7 +146,7 @@ export default class Api extends ToolApi {
 
   writeCheckData(payload = {}, checkPath) {
     const modifiedTimestamp = generateTimestamp();
-    const newFilename = modifiedTimestamp + '.json';;
+    const newFilename = modifiedTimestamp + '.json';
     payload.modifiedTimestamp = newFilename;
     fs.outputJSONSync(path.join(checkPath, newFilename.replace(/[:"]/g, '_')), payload);
   }

--- a/src/Api.js
+++ b/src/Api.js
@@ -114,7 +114,8 @@ export default class Api extends ToolApi {
                 bookId,
                 chapter,
                 verse,
-                projectSaveLocation
+                projectSaveLocation,
+                checkingOccurrence.contextId.quote
               );
               //If selections are changed, they need to be clearded
               selectionsChanged = true;
@@ -122,6 +123,7 @@ export default class Api extends ToolApi {
               const invalidatedPayload = {
                 ...selectionsObject,
                 invalidated: true,
+                selections: [],
                 userName
               };
               this.writeCheckData(invalidatedPayload, invalidatedCheckPath);
@@ -147,7 +149,7 @@ export default class Api extends ToolApi {
   writeCheckData(payload = {}, checkPath) {
     const modifiedTimestamp = generateTimestamp();
     const newFilename = modifiedTimestamp + '.json';
-    payload.modifiedTimestamp = newFilename;
+    payload.modifiedTimestamp = modifiedTimestamp;
     fs.outputJSONSync(path.join(checkPath, newFilename.replace(/[:"]/g, '_')), payload);
   }
 

--- a/src/Api.js
+++ b/src/Api.js
@@ -405,6 +405,6 @@ export default class Api extends ToolApi {
         translate
       }
     } = this.props;
-    this.props.tc.showIgnorableAlert('selections_invalidated', translate('selections_invalidated'));
+    this.props.tc.showIgnorableDialog('selections_invalidated', translate('selections_invalidated'));
   }
 }

--- a/src/helpers/validationHelpers.js
+++ b/src/helpers/validationHelpers.js
@@ -55,7 +55,7 @@ export function getSelectionsFromChapterAndVerseCombo(bookId, chapter, verse, pr
       sorted = sorted.filter((filename) => {
         const currentSelectionsObject = fs.readJsonSync(path.join(selectionsPath, filename));
         return currentSelectionsObject.contextId.quote === quote;
-      })
+      });
     }
     const filename = sorted[0];
     selectionsObject = fs.readJsonSync(path.join(selectionsPath, filename));

--- a/src/helpers/validationHelpers.js
+++ b/src/helpers/validationHelpers.js
@@ -26,7 +26,7 @@ export function sameContext(contextId1, contextId2) {
  * @param {String} str A date string. If null, will be current date
  * @return {String} The timestamp in milliseconds
  ******************************************************************************/
-export function generateTimestamp(str){
+export function generateTimestamp(str) {
   if (!str) {
     return (new Date()).toJSON();
   } else {
@@ -34,7 +34,7 @@ export function generateTimestamp(str){
   }
 }
 
-export function getSelectionsFromChapterAndVerseCombo(bookId, chapter, verse, projectSaveLocation) {
+export function getSelectionsFromChapterAndVerseCombo(bookId, chapter, verse, projectSaveLocation, quote = "") {
   let selectionsObject = {};
   const contextId = {
     reference: {
@@ -50,7 +50,13 @@ export function getSelectionsFromChapterAndVerseCombo(bookId, chapter, verse, pr
     files = files.filter(file => { // filter the filenames to only use .json
       return path.extname(file) === '.json';
     });
-    const sorted = files.sort().reverse(); // sort the files to use latest
+    let sorted = files.sort().reverse(); // sort the files to use latest
+    if (quote) {
+      sorted = sorted.filter((filename) => {
+        const currentSelectionsObject = fs.readJsonSync(path.join(selectionsPath, filename));
+        return currentSelectionsObject.contextId.quote === quote;
+      })
+    }
     const filename = sorted[0];
     selectionsObject = fs.readJsonSync(path.join(selectionsPath, filename));
   }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR fixes clearing invalidated selections on project selection. Because the store is not initialized with conextId data when the project is selected we cannot use the regular workflow for invalidating selections (which is writing to the reducer and having the save logic see the change and write to disk)

#### Please include detailed Test instructions for your pull request:
- Download the files below and unzip them. Paste the first folder into your projects directory (~/translationCore/projects/...)
[project to start with](https://github.com/translationCoreApps/translationWords/files/2953401/en_mcb_tit_book.zip)
[project to import](https://github.com/translationCoreApps/translationWords/files/2953400/57-TIT.usfm.zip)
- Open tC and you should see the project en_mcb_tit_book there
- Import the usfm file that you unzipped and give it the same identifier as the other project (mcb)
- You should get a overwrite notification as usual. You should see the invalidated selections dialog. (note: The invalidated alignment dialog should not show)
- Open tW
- You should be navigated to the check admonish. and the accuse check should not have 100% completed checks. It should be at 0 (without you having to navigate to the check).
- Note: If you repeat the steps on a branch without this fix the check should be at 100% until you navigate to it. Which would be a display of the bug fixed in the [issue # b](https://github.com/unfoldingWord-dev/translationCore/issues/5686#issuecomment-467555033).


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords/262)
<!-- Reviewable:end -->
