### PR TITLE
Bugfix 5970/fix bug with quote arrays and group menu

### DIFF
--- a/__tests__/GroupMenuContainer.test.js
+++ b/__tests__/GroupMenuContainer.test.js
@@ -1,0 +1,52 @@
+/* eslint-env jest */
+import * as GroupMenuContainer from '../src/containers/GroupMenuContainer';
+
+describe('GroupMenuContainer.generateItemId', () => {
+
+  it('should handle string quote', () => {
+    // given
+    const contextID = {
+      "reference": {"bookId": "luk", "chapter": 1, "verse": 5},
+      "tool": "translationWords",
+      "groupId": "aaron",
+      "quote": "Ἀαρών",
+      "strong": ["G00020"],
+      "occurrence": 1
+    };
+    const expectedAlignedGLText = "1:Ἀαρών:5:1:luk";
+
+    // when
+    const alignedGLText = GroupMenuContainer.generateItemId(contextID.occurrence, contextID.reference.bookId,
+      contextID.reference.chapter, contextID.reference.verse, contextID.quote);
+
+    // then
+    expect(alignedGLText).toEqual(expectedAlignedGLText);
+  });
+
+  it('should handle quote array', () => {
+    // given
+    const contextID = {
+      "reference":{"bookId":"luk","chapter":22,"verse":30},
+      "tool":"translationWords",
+      "groupId":"12tribesofisrael",
+      "quote":[
+        {"word":"δώδεκα","occurrence":1},
+        {"word":"φυλὰς","occurrence":1},
+        {"word":"κρίνοντες","occurrence":1},
+        {"word":"τοῦ","occurrence":1},
+        {"word":"Ἰσραήλ","occurrence":1}
+      ],
+      "strong":["G14270","G54430","G29190","G35880","G24740"],
+      "occurrence":1};
+    const expectedAlignedGLText = "1:δώδεκα:1:φυλὰς:1:κρίνοντες:1:τοῦ:1:Ἰσραήλ:30:22:luk";
+
+    // when
+    const alignedGLText = GroupMenuContainer.generateItemId(contextID.occurrence, contextID.reference.bookId,
+      contextID.reference.chapter, contextID.reference.verse, contextID.quote);
+
+    // then
+    expect(alignedGLText).toEqual(expectedAlignedGLText);
+  });
+
+});
+

--- a/src/containers/GroupMenuContainer.js
+++ b/src/containers/GroupMenuContainer.js
@@ -11,13 +11,14 @@ function generateItemId(occurrence, bookId, chapter, verse, quote) {
   if (Array.isArray(quote)) { // is a bit more complicated
     const parts = [];
     for (let i = 0, l = quote.length; i < l; i++) {
-      parts.push(quote.occurrence + ":" + quote.word);
+      const quotePart = quote[i];
+      parts.push(quotePart.occurrence + ":" + quotePart.word);
     }
     quoteId = parts.join(":");
   } else {
     quoteId = `${occurrence}:${quote}`;
   }
-  return `${bookId}:${chapter}:${verse}:${quoteId}`;
+  return `${quoteId}:${verse}:${chapter}:${bookId}`;
 }
 
 class GroupMenuContainer extends React.Component {

--- a/src/containers/GroupMenuContainer.js
+++ b/src/containers/GroupMenuContainer.js
@@ -6,6 +6,20 @@ import ModeCommentIcon from '@material-ui/icons/ModeComment';
 import EditIcon from '@material-ui/icons/Edit';
 import {GroupedMenu, generateMenuData, generateMenuItem, InvalidatedIcon, CheckIcon} from 'tc-ui-toolkit';
 
+function generateItemId(occurrence, bookId, chapter, verse, quote) {
+  let quoteId = "";
+  if (Array.isArray(quote)) { // is a bit more complicated
+    const parts = [];
+    for (let i = 0, l = quote.length; i < l; i++) {
+      parts.push(quote.occurrence + ":" + quote.word);
+    }
+    quoteId = parts.join(":");
+  } else {
+    quoteId = `${occurrence}:${quote}`;
+  }
+  return `${bookId}:${chapter}:${verse}:${quoteId}`;
+}
+
 class GroupMenuContainer extends React.Component {
 
   /**
@@ -49,7 +63,7 @@ class GroupMenuContainer extends React.Component {
     return {
       ...item,
       title: `${passageText} ${selectionText}`,
-      itemId: `${occurrence}:${bookId}:${chapter}:${verse}:${quote}`,
+      itemId: generateItemId(occurrence, bookId, chapter, verse, quote),
       finished: !!item.selections && !item.invalidated,
       tooltip: selectionText
     };

--- a/src/containers/GroupMenuContainer.js
+++ b/src/containers/GroupMenuContainer.js
@@ -6,7 +6,7 @@ import ModeCommentIcon from '@material-ui/icons/ModeComment';
 import EditIcon from '@material-ui/icons/Edit';
 import {GroupedMenu, generateMenuData, generateMenuItem, InvalidatedIcon, CheckIcon} from 'tc-ui-toolkit';
 
-function generateItemId(occurrence, bookId, chapter, verse, quote) {
+export function generateItemId(occurrence, bookId, chapter, verse, quote) {
   let quoteId = "";
   if (Array.isArray(quote)) { // is a bit more complicated
     const parts = [];


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix for bug that all instances in a verse were shown selected in tW checks

#### Please include detailed Test instructions for your pull request:
- test with tCore branch v1.1.4.  
- open a Luke project in tW.  Luke 17:20 when selected should not highlight both instances.
- also for [41-MAT.usfm.zip](https://github.com/unfoldingWord-dev/translationCore/files/3138284/41-MAT.usfm.zip), check Mat 24:30 and 26:24 under Son of Man
- I will follow up with a PR to merge this into tCore 1.1.4

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationwords/272)
<!-- Reviewable:end -->
